### PR TITLE
console fix for hack purposes

### DIFF
--- a/background.js
+++ b/background.js
@@ -96,7 +96,12 @@ function patchAppCode(appCode) {
 			name: "Window.appk fix",
 			from: /([A-Za-z_]).storeGeneric\("error","error"\),([A-Za-z_]).enabled=!1,e&&e.ws&&e.ws.close\(\);var t=document.body;if\(t\){for\(;t.firstChild;\)t.removeChild\(t.firstChild\);r\(t\)}/g,
 			to: ""
-		}
+		},
+		{
+			name: "Console fix",
+			from: /n=void 0!==function\(e,t\)/g,
+			to: "n=true||void 0!==function\(e,t\)"
+		},
 		// {
 		// 	name: "Window onerror",
 		// 	from: /window.onerror/g,


### PR DESCRIPTION
i spent two days for understanding javascript and your extension (hack).
and it was so hard to hack console log. And then i saw that my console fix is very similar to zbot473/SurvivHacks and i could use zbot473 fix, but i fixed console in a little bit different way.

the var n which i modifying in patch is a boolean that allow access to dev console.